### PR TITLE
Add an overloaded method on `Query.select(offset, limit)`

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/Query.java
+++ b/db/src/main/java/com/psddev/dari/db/Query.java
@@ -1507,6 +1507,15 @@ public class Query<E> extends Record {
     public PaginatedResult<E> select(long offset, int limit) {
         return getDatabase().readPartial(this, offset, limit);
     }
+    
+    /**
+     * Returns a partial list of all objects matching this query
+     * starting from the given {@code offset} 
+     * in a {@linkplain #getDatabase database}.
+     */
+    public PaginatedResult<E> select(long offset) {
+        return select(offset, Integer.MAX_VALUE);
+    }    
 
     /**
      * Returns a list of all objects matching this query in a


### PR DESCRIPTION
This PR adds an overloaded method for getting back a `PaginatedResult`. The new method just uses the existing `select` method for getting paginated result set. This is useful in cases where the developer wants all the objects starting from some offset & it wants all the objects after it without knowing how many items are present after it.