### PR TITLE
value nodes will use value of [content] attribute when available

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
+++ b/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,11 @@ public class HtmlMicrodata {
                 value = ObjectUtils.firstNonNull(prop.attr("datetime"), prop.text());
 
             } else {
-                value = prop.text();
+                if(prop.hasAttr("content")) {
+                    value = prop.attr("content");
+                } else {
+                    value = prop.text();
+                }
             }
 
             if (!ObjectUtils.isBlank(names)) {
@@ -256,6 +261,23 @@ public class HtmlMicrodata {
          */
         public static List<HtmlMicrodata> parseUrl(URL url) throws IOException {
             return parseString(url, IoUtils.toString(url));
+        }
+
+        /**
+         * Returns the first HtmlMicrodata instance in the list that matches one of the supplied schema types, or null if none match
+         * @param htmlMicrodatas
+         * @param allowedSchemaTypes
+         * @return
+         */
+        public static HtmlMicrodata getFirstType(List<HtmlMicrodata> htmlMicrodatas, Collection<String> allowedSchemaTypes) {
+            for(HtmlMicrodata htmlMicrodata : htmlMicrodatas) {
+                for (String allowedSchemaType : allowedSchemaTypes) {
+                    if (htmlMicrodata.getTypes().contains(allowedSchemaType)) {
+                        return htmlMicrodata;
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
+++ b/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
@@ -96,7 +96,15 @@ public class HtmlMicrodata {
                 value = prop.attr("value");
 
             } else if (" time ".contains(tagName)) {
-                value = ObjectUtils.firstNonNull(prop.attr("datetime"), prop.text());
+                if (prop.hasAttr("datetime")) {
+                    value = prop.attr("datetime");
+                } else if (prop.hasAttr("content")) {
+                    value = prop.attr("content");
+                } else {
+                    value = prop.text();
+                }
+                // this older version was returning empty string... prop.attr returning non-null?
+                // value = ObjectUtils.firstNonNull(prop.attr("datetime"), prop.attr("content"), prop.text());
 
             } else {
                 if (prop.hasAttr("content")) {

--- a/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
+++ b/util/src/main/java/com/psddev/dari/util/HtmlMicrodata.java
@@ -99,7 +99,7 @@ public class HtmlMicrodata {
                 value = ObjectUtils.firstNonNull(prop.attr("datetime"), prop.text());
 
             } else {
-                if(prop.hasAttr("content")) {
+                if (prop.hasAttr("content")) {
                     value = prop.attr("content");
                 } else {
                     value = prop.text();
@@ -270,7 +270,7 @@ public class HtmlMicrodata {
          * @return
          */
         public static HtmlMicrodata getFirstType(List<HtmlMicrodata> htmlMicrodatas, Collection<String> allowedSchemaTypes) {
-            for(HtmlMicrodata htmlMicrodata : htmlMicrodatas) {
+            for (HtmlMicrodata htmlMicrodata : htmlMicrodatas) {
                 for (String allowedSchemaType : allowedSchemaTypes) {
                     if (htmlMicrodata.getTypes().contains(allowedSchemaType)) {
                         return htmlMicrodata;

--- a/util/src/test/java/com/psddev/dari/util/HtmlMicrodataTest.java
+++ b/util/src/test/java/com/psddev/dari/util/HtmlMicrodataTest.java
@@ -100,6 +100,29 @@ public class HtmlMicrodataTest {
         assertEquals("PT30M", microdata.getFirstProperty("prepTime"));
     }
 
+
+    @Test
+    public void Static_parse_time_datetime() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] { "http://schema.org/Recipe" }));
+        assertEquals("PT15M", microdata.getFirstProperty("cookTimeDateTime"));
+    }
+
+    @Test
+    public void Static_parse_time_content() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] { "http://schema.org/Recipe" }));
+        assertEquals("PT14M", microdata.getFirstProperty("cookTimeContent"));
+    }
+
+    @Test
+    public void Static_parse_time_value() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] { "http://schema.org/Recipe" }));
+        assertEquals("13 mins", microdata.getFirstProperty("cookTimeValue"));
+    }
+
+
     /** UTILITY **/
     public static Document getDocument(String file) {
         try {

--- a/util/src/test/java/com/psddev/dari/util/HtmlMicrodataTest.java
+++ b/util/src/test/java/com/psddev/dari/util/HtmlMicrodataTest.java
@@ -1,0 +1,114 @@
+package com.psddev.dari.util;
+
+import com.psddev.dari.util.TestUtils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.psddev.dari.util.ObjectUtils;
+
+/**
+ * Created by rhseeger on 12/17/14.
+ */
+public class HtmlMicrodataTest {
+    @Rule public TestName testName = new TestName();
+    public static URL testUrl;
+
+    @BeforeClass
+    public static void beforeClass() {
+        try {
+            testUrl = new URL("http://www.test.me/this/is/a/test/url");
+        } catch(Exception ex) {}
+    }
+
+    @AfterClass
+    public static void afterClass() {}
+
+    @Before
+    public void before() {
+        System.out.println("Running test [" + testName.getMethodName() + "]");
+    }
+
+    @After
+    public void after() {}
+
+	/* public static HtmlMicrodata getFirstType(List<HtmlMicrodata> htmlMicrodatas, Collection<String> allowedSchemaTypes) */
+
+    @Test
+    public void Static_getFirstType_valid() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] {
+                "http://schema.org/Recipe"
+        }));
+        assertEquals("http://schema.org/Recipe", microdata.getFirstType());
+    }
+
+    @Test
+    public void Static_getFirstType_notFirst() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] {
+                "http://schema.org/NotRecipe",
+                "http://schema.org/Recipe"
+        }));
+        assertEquals("http://schema.org/Recipe", microdata.getFirstType());
+    }
+
+    @Test
+    public void Static_getFirstType_invalid() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] {
+                "http://schema.org/NotRecipe"
+        }));
+        assertEquals(null, microdata);
+    }
+
+    /* Generic parsing functionality, values */
+
+    @Test
+    public void Static_parse_value_text() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] { "http://schema.org/Recipe" }));
+        assertEquals("Mexican Rigatoni and Cheese", microdata.getFirstProperty("name"));
+    }
+
+    @Test
+    public void Static_parse_value_content() {
+        List<HtmlMicrodata> microdatas = HtmlMicrodata.Static.parseDocument(testUrl, getDocument("simple-content.html"));
+        HtmlMicrodata microdata = HtmlMicrodata.Static.getFirstType(microdatas, Arrays.asList(new String[] { "http://schema.org/Recipe" }));
+        assertEquals("PT30M", microdata.getFirstProperty("prepTime"));
+    }
+
+    /** UTILITY **/
+    public static Document getDocument(String file) {
+        try {
+            String html = TestUtils.loadSampleFile("com/psddev/dari/util/HtmlMicrodata_Test/" + file);
+            Parser parser = Parser.htmlParser();
+            return parser.parseInput(html, testUrl.toString());
+        } catch(IOException ex) {
+            return null;
+        }
+    }
+
+}

--- a/util/src/test/java/com/psddev/dari/util/TestUtils.java
+++ b/util/src/test/java/com/psddev/dari/util/TestUtils.java
@@ -1,0 +1,44 @@
+package com.psddev.dari.util;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.junit.Ignore;
+
+@Ignore
+public class TestUtils {
+	public static String loadSampleFile(String filename) throws IOException {
+		InputStream in = TestUtils.class.getClassLoader().getResourceAsStream(filename);
+		if(in == null) {
+			throw new FileNotFoundException("The resource file could not be found: " + filename);
+		}
+		return getStringFromInputStream(in);
+	}
+	
+	private static String getStringFromInputStream(InputStream is) throws IOException {
+		BufferedReader br = null;
+		StringBuilder sb = new StringBuilder();
+
+		String line;
+		try {
+ 
+			br = new BufferedReader(new InputStreamReader(is));
+			while ((line = br.readLine()) != null) {
+				sb.append(line);
+			}
+		} finally {
+			if (br != null) {
+				try {
+					br.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+ 
+		return sb.toString();
+	}
+}

--- a/util/src/test/resources/com/psddev/dari/util/HtmlMicrodata_Test/simple-content.html
+++ b/util/src/test/resources/com/psddev/dari/util/HtmlMicrodata_Test/simple-content.html
@@ -17,6 +17,21 @@
         <span itemprop="prepTime" content="PT30M">30 mins</span>
     </div>
 
+    <div>
+        <span>Cook Time DateTime:</span>
+        <time itemprop="cookTimeDateTime" datetime="PT15M">15 mins</time>
+    </div>
+
+    <div>
+        <span>Cook Time Content:</span>
+        <time itemprop="cookTimeContent" content="PT14M">14 mins</time>
+    </div>
+
+    <div>
+        <span>Cook Time Value:</span>
+        <time itemprop="cookTimeValue">13 mins</time>
+    </div>
+
 </div>
 
 </body>

--- a/util/src/test/resources/com/psddev/dari/util/HtmlMicrodata_Test/simple-content.html
+++ b/util/src/test/resources/com/psddev/dari/util/HtmlMicrodata_Test/simple-content.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<head>
+    <title>Test Page for HtmlMicrodata / Value Nodes</title>
+</head>
+
+<body>
+
+<div itemscope itemtype="http://schema.org/Recipe">
+
+    <div>
+        <h1 itemprop="name">Mexican Rigatoni and Cheese</h1>
+    </div>
+
+    <div>
+        <span>Prep:</span>
+        <span itemprop="prepTime" content="PT30M">30 mins</span>
+    </div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Value nodes with a [content] attribute will now pull from that attribute... rather than the value of text(). For example:

    <div>
        <h1 itemprop="name">Mexican Rigatoni and Cheese</h1>
    </div>

    <div>
        <span>Prep:</span>
        <span itemprop="prepTime" content="PT30M">30 mins</span>
    </div>

The value for the [_name_] property will continue to be "_Mexican Rigatoni and Cheese_". The value for the [_prepTime_] attribute will be "_PT30M_" instead of [30 mins].
