### PR TITLE
BSP-878 Fixes bug where replicationCache produces objects by ID for incompatible types.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
@@ -1156,6 +1156,24 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
                     continue;
                 }
 
+                // Restrict objects based on the types requested by the query
+                if (query != null && (!ObjectUtils.isBlank(query.getGroup()) || query.getObjectClass() != null)) {
+
+                    UUID typeId = ObjectUtils.to(UUID.class, (byte[]) value[0]);
+
+                    if (typeId != null) {
+
+                        ObjectType type = ObjectType.getInstance(typeId);
+
+                        if (type != null &&
+                                ((!ObjectUtils.isBlank(query.getGroup()) && !type.getGroups().contains(query.getGroup())) ||
+                                        (query.getObjectClass() != null && type.getObjectClass() != null && !query.getObjectClass().isAssignableFrom(type.getObjectClass())))) {
+
+                            continue;
+                        }
+                    }
+                }
+
                 @SuppressWarnings("unchecked")
                 T object = createSavedObjectFromReplicationCache((byte[]) value[0], id, (byte[]) value[1], (Map<String, Object>) value[2], query);
 


### PR DESCRIPTION
Avoids producing objects in SqlDatabase/findObjectsFromReplicationCache when the objects’ type does not match the requested Query/objectClass and Query/group.