### PR TITLE
Deprecates Application.initialize, as it is only invoked from a @Deprecated class.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/Application.java
+++ b/db/src/main/java/com/psddev/dari/db/Application.java
@@ -56,6 +56,7 @@ public class Application extends Record {
      * {@code logger}. By default, this method does nothing, so the
      * subclasses are expected to override it to provide the desired behavior.
      */
+    @Deprecated
     public void initialize(Logger logger) throws Exception {
     }
 


### PR DESCRIPTION
Deprecates Application.initialize, as it is only invoked from a @Deprecated class.  Any @Overriding implementations in derived classes are not invoked during normal Application functionality.