### PR TITLE
Fixes bug in sqlQueryCache Query equivalence.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/Query.java
+++ b/db/src/main/java/com/psddev/dari/db/Query.java
@@ -1408,6 +1408,7 @@ public class Query<E> extends Record {
                     ObjectUtils.equals(predicate, otherQuery.predicate) &&
                     ObjectUtils.equals(getSorters(), otherQuery.getSorters()) &&
                     ObjectUtils.equals(getDatabase(), otherQuery.getDatabase()) &&
+                    ObjectUtils.equals(getFields(), otherQuery.getFields()) &&
                     isResolveToReferenceOnly == otherQuery.isResolveToReferenceOnly &&
                     ObjectUtils.equals(timeout, otherQuery.timeout);
 
@@ -1424,6 +1425,7 @@ public class Query<E> extends Record {
                 getPredicate(),
                 getSorters(),
                 getDatabase(),
+                getFields(),
                 isResolveToReferenceOnly(),
                 getTimeout());
     }

--- a/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
@@ -762,7 +762,6 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
             newBuilder().
             maximumSize(5000).
             concurrencyLevel(20).
-            weakKeys().
             build(new CacheLoader<Query<?>, String>() {
                 @Override
                 public String load(Query<?> query) throws Exception {

--- a/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
@@ -753,10 +753,6 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
 
     /**
      * Maintains a cache of Querys to SQL select statements.
-     *
-     * This cache sets the Database of the Query to null to
-     * avoid keeping a reference to the CachingDatabase, so
-     * only call it with a clone of your query with a null Database.
      */
     private final LoadingCache<Query<?>, String> sqlQueryCache = CacheBuilder.
             newBuilder().
@@ -765,9 +761,7 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
             build(new CacheLoader<Query<?>, String>() {
                 @Override
                 public String load(Query<?> query) throws Exception {
-                    String sql = new SqlQuery(SqlDatabase.this, query).selectStatement();
-                    query.setDatabase(null);
-                    return sql;
+                    return new SqlQuery(SqlDatabase.this, query).selectStatement();
                 }
             });
 
@@ -778,7 +772,8 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
     public String buildSelectStatement(Query<?> query) {
         try {
             Query<?> strippedQuery = query.clone();
-            strippedQuery.setDatabase(null);
+            // Remove any possibility that multiple CachingDatabases will be cached in the sqlQueryCache.
+            strippedQuery.setDatabase(this);
             return sqlQueryCache.getUnchecked(strippedQuery);
         } catch (UncheckedExecutionException e) {
             Throwable cause = e.getCause();


### PR DESCRIPTION
Changes sqlQueryCache to not use weakKeys() and fixes Query#equals() and
hashCode() to include fields, as getFields() is used to build the query.