### PR TITLE
Update to have JunctionFields perform a full save (with beforeSave) o…

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/AbstractDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/AbstractDatabase.java
@@ -202,7 +202,9 @@ public abstract class AbstractDatabase<C> implements Database {
                                 }
 
                                 if (save) {
-                                    addToSaves(itemState);
+                                    if(!saves.contains(itemState)) {
+                                        itemState.save();
+                                    }
                                 }
                             }
                         }
@@ -212,7 +214,9 @@ public abstract class AbstractDatabase<C> implements Database {
                         State itemState = State.getInstance(item);
 
                         itemState.remove(junctionField);
-                        addToSaves(itemState);
+                        if(!saves.contains(itemState)) {
+                            itemState.save();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…n children

When saving an object with a JunctionField, the original code was (effectively) performing a saveUnsafely. This changes that so a full save (with validation/beforeSave/etc) is performed instead.