### PR TITLE
Adds unit tests for PredicateParser$Static#evaluate.

### DIFF
--- a/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
+++ b/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
@@ -254,8 +254,6 @@ public class PredicateParserTest {
     	assertEquals(null, parser.parse(" ( ) "));
     }
 
-    /** evaluate reflective identity "?" syntax **/
-
     public void evaluate_reflective_syntax(String reflectiveSyntax) {
         for (Database database : DATABASES) {
 
@@ -281,6 +279,8 @@ public class PredicateParserTest {
             assertTrue("\"" + reflectiveSyntax + "\" was evaluated incorrectly!", PredicateParser.Static.evaluate(other, "other = " + reflectiveSyntax, current.getState()));
         }
     }
+
+    /** evaluate reflective identity "?" syntax **/
 
     @Test
     public void evaluate_reflective_identity_syntax_standard() {

--- a/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
+++ b/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
@@ -324,12 +324,6 @@ public class PredicateParserTest {
         parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_SYNTAX_STANDARD);
     }
 
-    /** Test reduction of a Recordable to a String field value using the syntax "?field" **/
-    @Test
-    public void parse_identity_standard_syntax_with_field() {
-        parse_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_SYNTAX_STANDARD);
-    }
-
     /** Test reduction of a Recordable to a UUID using the identity syntax "?/" **/
     @Test
     @Ignore
@@ -343,13 +337,6 @@ public class PredicateParserTest {
     @Ignore
     public void parse_identity_delimited_syntax_with_field() {
         parse_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_DELIMITED_SYNTAX);
-    }
-
-    /** Test reduction of a Recordable to a UUID using the identity syntax "?_id" **/
-    @Test
-    public void parse_identity_redundant_syntax() {
-
-        parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_REDUNDANT_SYNTAX);
     }
 
     /** Test reduction of a Recordable to a UUID using the identity syntax "?/_id" **/
@@ -367,13 +354,6 @@ public class PredicateParserTest {
         parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_SYNTAX);
     }
 
-    /** Test reduction of a Recordable to a String field value using the syntax "?0field" **/
-    @Test
-    @Ignore
-    public void parse_identity_indexed_syntax_with_field() {
-        parse_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_SYNTAX);
-    }
-
     /** Test reduction of a Recordable to a UUID using the identity syntax "?0/" **/
     @Test
     public void parse_identity_indexed_delimited_syntax() {
@@ -387,15 +367,7 @@ public class PredicateParserTest {
         parse_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_SYNTAX);
     }
 
-    /** Test reduction of a Recordable to a UUID using the identity syntax "?0_id" **/
-    @Test
-    @Ignore
-    public void parse_identity_indexed_redundant_syntax() {
-
-        parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_REDUNDANT_SYNTAX);
-    }
-
-    /** Test reduction of a Recordable to a UUID using the identity syntax "?0_id" **/
+    /** Test reduction of a Recordable to a UUID using the identity syntax "?0/_id" **/
     @Test
     public void parse_identity_indexed_delimited_redundant_syntax() {
 

--- a/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
+++ b/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
@@ -1,25 +1,73 @@
 package com.psddev.dari.db;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Queue;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PredicateParserTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PredicateParserTest.class);
+
+    private static final String REFLECTIVE_IDENTITY_SYNTAX_STANDARD = "?";
+    private static final String REFLECTIVE_IDENTITY_DELIMITED_SYNTAX = "?/";
+    private static final String REFLECTIVE_IDENTITY_REDUNDANT_SYNTAX = "?_id";
+    private static final String REFLECTIVE_IDENTITY_DELIMITED_REDUNDANT_SYNTAX = "?/_id";
+    private static final String REFLECTIVE_IDENTITY_INDEXED_SYNTAX = "?0";
+    private static final String REFLECTIVE_IDENTITY_INDEXED_DELIMITED_SYNTAX = "?0/";
+    private static final String REFLECTIVE_IDENTITY_INDEXED_REDUNDANT_SYNTAX = "?0_id";
+    private static final String REFLECTIVE_IDENTITY_INDEXED_DELIMITED_REDUNDANT_SYNTAX = "?0/_id";
+
+    private static List<TestDatabase> TEST_DATABASES;
+    private static List<Database> DATABASES;
+
 	PredicateParser parser = new PredicateParser();
 	static final Queue<Object> EMPTY_OBJECT_QUEUE = new ArrayDeque<Object>();
 	static final Queue<String> EMPTY_STRING_QUEUE = new ArrayDeque<String>();
 
+    @BeforeClass
+    public static void beforeClass() {
+
+        TEST_DATABASES = DatabaseTestUtils.getNewDefaultTestDatabaseInstances();
+        DATABASES = new ArrayList<Database>();
+
+        for (TestDatabase testDb : TEST_DATABASES) {
+            Database db = testDb.get();
+            DATABASES.add(db);
+        }
+
+        LOGGER.info("Running tests against " + TEST_DATABASES.size() + " databases.");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (TEST_DATABASES != null) for (TestDatabase testDb : TEST_DATABASES) {
+            testDb.close();
+        }
+    }
+
     @Before
-    public void before() {}
+    public void before() {
+
+    }
 
     @After
-    public void after() {}
+    public void after() {
+
+    }
 
     /**
      * public Predicate parse(String predicateString, Object... parameters)
@@ -204,6 +252,170 @@ public class PredicateParserTest {
     @Test (expected=IllegalArgumentException.class)
     public void parse_parens_empty() {
     	assertEquals(null, parser.parse(" ( ) "));
+    }
+
+    /** evaluate reflective identity "?" syntax **/
+
+    public void evaluate_reflective_syntax(String reflectiveSyntax) {
+        for (Database database : DATABASES) {
+
+            ReflectiveTestRecord current = ReflectiveTestRecord.getInstance(database);
+            ReflectiveTestRecord other = ReflectiveTestRecord.getInstance(database);
+
+            current.setOther(other);
+            other.setOther(current);
+
+            assertTrue("\"" + reflectiveSyntax + "\" was evaluated incorrectly!", PredicateParser.Static.evaluate(other, "other = " + reflectiveSyntax, current));
+        }
+    }
+
+    public void evaluate_reflective_syntax_state_valued(String reflectiveSyntax) {
+        for (Database database : DATABASES) {
+
+            ReflectiveTestRecord current = ReflectiveTestRecord.getInstance(database);
+            ReflectiveTestRecord other = ReflectiveTestRecord.getInstance(database);
+
+            current.setOther(other);
+            other.setOther(current);
+
+            assertTrue("\"" + reflectiveSyntax + "\" was evaluated incorrectly!", PredicateParser.Static.evaluate(other, "other = " + reflectiveSyntax, current.getState()));
+        }
+    }
+
+    @Test
+    public void evaluate_reflective_identity_syntax_standard() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_SYNTAX_STANDARD);
+    }
+
+    @Test
+    public void evaluate_reflective_identity_syntax_standard_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_SYNTAX_STANDARD);
+    }
+
+    /** evaluate reflective identity delimited "?/" syntax **/
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_delimited_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_DELIMITED_SYNTAX);
+    }
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_delimited_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_DELIMITED_SYNTAX);
+    }
+
+    /** evaluate reflective identity redundant "?_id" syntax **/
+
+    @Test
+    public void evaluate_reflective_identity_redundant_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_REDUNDANT_SYNTAX);
+    }
+
+    @Test
+    public void evaluate_reflective_identity_redundant_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_REDUNDANT_SYNTAX);
+    }
+
+    /** evaluate reflective identity delimited redundant "?/_id" syntax **/
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_delimited_redundant_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_DELIMITED_REDUNDANT_SYNTAX);
+    }
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_delimited_redundant_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_DELIMITED_REDUNDANT_SYNTAX);
+    }
+
+    /** evaluate reflective identity indexed "?0" syntax **/
+
+    @Test
+    public void evaluate_reflective_identity_indexed_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_INDEXED_SYNTAX);
+    }
+
+    @Test
+    public void evaluate_reflective_identity_indexed_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_INDEXED_SYNTAX);
+    }
+
+    /** evaluate reflective identity indexed delimited "?0/" syntax **/
+
+    @Test
+    public void evaluate_reflective_identity_indexed_delimited_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_SYNTAX);
+    }
+
+    @Test
+    public void evaluate_reflective_identity_indexed_delimited_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_SYNTAX);
+    }
+
+    /** evaluate reflective identity indexed redundant "?0_id" syntax **/
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_indexed_redundant_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_INDEXED_REDUNDANT_SYNTAX);
+    }
+
+    @Test
+    @Ignore
+    public void evaluate_reflective_identity_indexed_redundant_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_INDEXED_REDUNDANT_SYNTAX);
+    }
+
+    /** evaluate reflective identity indexed delimited redundant "?0/_id" syntax **/
+
+    @Test
+    public void evaluate_reflective_identity_indexed_delimited_redundant_syntax() {
+
+        evaluate_reflective_syntax(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_REDUNDANT_SYNTAX);
+    }
+
+    @Test
+    public void evaluate_reflective_identity_indexed_delimited_redundant_syntax_state_valued() {
+
+        evaluate_reflective_syntax_state_valued(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_REDUNDANT_SYNTAX);
+    }
+
+    public static class ReflectiveTestRecord extends Record {
+
+        public static ReflectiveTestRecord getInstance(Database database) {
+
+            ReflectiveTestRecord object = new ReflectiveTestRecord();
+            object.getState().setDatabase(database);
+            return object;
+        }
+
+        private ReflectiveTestRecord other;
+
+        public ReflectiveTestRecord getOther() {
+            return other;
+        }
+
+        public void setOther(ReflectiveTestRecord other) {
+            this.other = other;
+        }
     }
 
     /*

--- a/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
+++ b/db/src/test/java/com/psddev/dari/db/PredicateParserTest.java
@@ -270,6 +270,32 @@ public class PredicateParserTest {
     }
 
     /**
+     * Utility method for testing unsupported identity syntax formats.
+     * @param identitySyntax the format string to test
+     */
+    private void illegal_identity_syntax_recordable(String identitySyntax) {
+
+        for (Database database : DATABASES) {
+
+            TestRecord current = TestRecord.getInstance(database);
+            parser.parse("record = " + identitySyntax, current);
+        }
+    }
+
+    /**
+     * Utility method for testing unsupported identity syntax formats in parsing predicates with field expressions.
+     * @param identitySyntax the format string to test
+     */
+    private void illegal_identity_with_field_syntax_recordable(String identitySyntax) {
+        for (Database database : DATABASES) {
+
+            TestRecord current = TestRecord.getInstance(database);
+            current.setName("testName");
+            parser.parse("record = " + identitySyntax + "name", current);
+        }
+    }
+
+    /**
      * Utility method for testing different identity syntax formats in parsing predicates with field expressions.
      * @param identitySyntax the format string to test
      */
@@ -304,7 +330,7 @@ public class PredicateParserTest {
      * Test reduction of a {@link Recordable} to a String field value in {@link ComparisonPredicate}
      */
     @Test
-    @Ignore
+    @Ignore // Unsupported
     public void parse_name_spaced_field_recordable() {
         for (Database database : DATABASES) {
 
@@ -317,6 +343,8 @@ public class PredicateParserTest {
         }
     }
 
+    /** Supported Syntax Tests **/
+
     /** Test reduction of a Recordable to a UUID using the identity syntax "?" **/
     @Test
     public void parse_identity_standard_syntax() {
@@ -326,7 +354,7 @@ public class PredicateParserTest {
 
     /** Test reduction of a Recordable to a UUID using the identity syntax "?/" **/
     @Test
-    @Ignore
+    @Ignore // Unsupported
     public void parse_identity_delimited_syntax() {
 
         parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_DELIMITED_SYNTAX);
@@ -334,14 +362,14 @@ public class PredicateParserTest {
 
     /** Test reduction of a Recordable to a String field value using the syntax "?/field" **/
     @Test
-    @Ignore
+    @Ignore // Unsupported
     public void parse_identity_delimited_syntax_with_field() {
         parse_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_DELIMITED_SYNTAX);
     }
 
     /** Test reduction of a Recordable to a UUID using the identity syntax "?/_id" **/
     @Test
-    @Ignore
+    @Ignore // Unsupported
     public void parse_identity_delimited_redundant_syntax() {
 
         parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_DELIMITED_REDUNDANT_SYNTAX);
@@ -372,6 +400,38 @@ public class PredicateParserTest {
     public void parse_identity_indexed_delimited_redundant_syntax() {
 
         parse_identity_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_DELIMITED_REDUNDANT_SYNTAX);
+    }
+
+    /** Illegal Syntax Tests, Expected Failures **/
+
+    /** Test reduction of a Recordable to a String field value using the syntax "?field" **/
+    @Test(expected=IllegalArgumentException.class)
+    @Ignore // Unsupported
+    public void illegal_identity_standard_syntax_with_field() {
+        illegal_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_SYNTAX_STANDARD);
+    }
+
+    /** Test reduction of a Recordable to a UUID using the identity syntax "?_id" **/
+    @Test(expected=IllegalArgumentException.class)
+    @Ignore // Unsupported
+    public void illegal_identity_redundant_syntax() {
+
+        illegal_identity_syntax_recordable(REFLECTIVE_IDENTITY_REDUNDANT_SYNTAX);
+    }
+
+    /** Test reduction of a Recordable to a String field value using the syntax "?0field" **/
+    @Test(expected=IllegalArgumentException.class)
+    @Ignore // Unsupported
+    public void illegal_identity_indexed_syntax_with_field() {
+        illegal_identity_with_field_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_SYNTAX);
+    }
+
+    /** Test reduction of a Recordable to a UUID using the identity syntax "?0_id" **/
+    @Test(expected=IllegalArgumentException.class)
+    @Ignore // Unsupported
+    public void illegal_identity_indexed_redundant_syntax() {
+
+        illegal_identity_syntax_recordable(REFLECTIVE_IDENTITY_INDEXED_REDUNDANT_SYNTAX);
     }
 
     /** Test Record type for parser identity syntax tests **/


### PR DESCRIPTION
Six @Test methods are @Ignored and will be activated after merge of bugfix/predicate-parser-reflective-syntax.
Ten @Test methods are activated to unit test currently supported reflective syntaxes.