### PR TITLE
Improves the hash algorithm for calculating the baseUrl

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/DimsImageEditor.java
+++ b/util/src/main/java/com/psddev/dari/util/DimsImageEditor.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -356,7 +357,7 @@ public class DimsImageEditor extends AbstractImageEditor {
             }
 
             if (!isDimsUrl) {
-                int bucketIndex = imageUrl.hashCode() % baseUrls.size();
+                int bucketIndex = ByteBuffer.wrap(StringUtils.md5(imageUrl)).getInt() % baseUrls.size();
                 if (bucketIndex < 0) {
                     bucketIndex *= -1;
                 }

--- a/util/src/main/java/com/psddev/dari/util/StorageItemPathHash.java
+++ b/util/src/main/java/com/psddev/dari/util/StorageItemPathHash.java
@@ -1,5 +1,6 @@
 package com.psddev.dari.util;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -12,7 +13,7 @@ public class StorageItemPathHash extends AbstractStorageItemHash {
     @Override
     public int hashStorageItem(StorageItem storageItem) {
         String path = storageItem.getPath();
-        return path != null ? path.hashCode() : 0;
+        return path != null ? ByteBuffer.wrap(StringUtils.md5(path)).getInt() : 0;
     }
 
     @Override


### PR DESCRIPTION
Uses MD5 hash so that it is more random and therefore more evenly distributed after the modulus is applied to the result.