### PR TITLE
Fixes JavaImageEditor modifying the existing image's metadata map.

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/JavaImageEditor.java
+++ b/util/src/main/java/com/psddev/dari/util/JavaImageEditor.java
@@ -315,10 +315,7 @@ public class JavaImageEditor extends AbstractImageEditor {
 
         newStorageItem.setContentType(contentType);
 
-        Map<String, Object> metadata = storageItem.getMetadata();
-        if (metadata == null) {
-            metadata = new HashMap<String, Object>();
-        }
+        Map<String, Object> metadata = new HashMap<String, Object>();
 
         // store the new width and height in the metadata map
         if (outputDimension != null && outputDimension.width != null) {


### PR DESCRIPTION
Always creates a new Map and copies the relevant metadata over.  Fixes issue where subsequent edits to the same image could result in incorrect crops. This is now consistent with DimsImageEditor.