### PR TITLE
Adds method TypeDefinition#getInferredGenericTypeArgumentClass.

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
+++ b/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
@@ -483,14 +483,7 @@ public class TypeDefinition<T> {
             return map;
         }
 
-        /**
-         * Gets all super classes with type variables defined starting from the
-         * {@code sourceClass}.
-         *
-         * @param sourceClass the class to check.
-         * @return a set of all super types of the {@code sourceClass} that has
-         *      type variables.
-         */
+        // Gets all super classes with type variables defined starting from the {@code sourceClass}
         private Set<Class<?>> getAllSuperTypesWithTypeVariables(Class<?> sourceClass) {
 
             Set<Class<?>> superTypes = new HashSet<>();
@@ -514,16 +507,8 @@ public class TypeDefinition<T> {
             return superTypes;
         }
 
-        /**
-         *
-         * @param sourceClass the class that extends/implements
-         *      {@code superClass} whose actual generic type argument class
-         *      should be fetched.
-         * @param superClass the class defining the generics.
-         * @param genericTypeArgumentIndex the index of the generic to fetch.
-         * @return the generic type argument class for the given
-         *      {@code sourceClass}.
-         */
+        // gets the inferred generic type argument class for the given {@code sourceClass}
+        // based on the give {@code superClass} generic type argument at the specified index.
         private Class<?> getInferredGenericTypeArgumentClass(Class<?> sourceClass, Class<?> superClass, int genericTypeArgumentIndex) {
 
             List<Map.Entry<Class<?>, Type>> hierarchy = getClassAndGenericSuperTypeHierarchy(sourceClass, superClass);
@@ -600,17 +585,9 @@ public class TypeDefinition<T> {
             return null;
         }
 
-        /**
-         * Returns the list of ClassInfo objects in the class hierarchy from
-         * {@code sourceClass} class to {@code superClass} class, where the
-         * first element in the list is {@code sourceClass}. If the two classes
-         * are not in the same hierarchy, an empty list returned.
-         *
-         * @param sourceClass the bottom starting class in the hierarchy.
-         * @param superClass the top most parent class or interface in the
-         *      hierarchy.
-         * @return the ClassInfo hierarchy list between the two class arguments.
-         */
+        // Returns the list of ClassInfo objects in the class hierarchy from {@code sourceClass}
+        // class to {@code superClass} class, where the first element in the list is {@code sourceClass}.
+        // If the two classes are not in the same hierarchy, an empty list returned.
         private List<Map.Entry<Class<?>, Type>> getClassAndGenericSuperTypeHierarchy(Class<?> sourceClass, Class<?> superClass) {
 
             List<Class<?>> classes = getClassHierarchy(sourceClass, superClass);
@@ -640,17 +617,9 @@ public class TypeDefinition<T> {
             return hierarchy;
         }
 
-        /**
-         * Returns the list of classes in the class hierarchy from
-         * {@code sourceClass} class to {@code superClass} class, where the
-         * first element in the list is {@code sourceClass}. If the two classes
-         * are not in the same hierarchy, {@code null} is returned.
-         *
-         * @param sourceClass the bottom starting class in the hierarchy.
-         * @param superClass the top most parent class or interface in the
-         *      hierarchy.
-         * @return the class hierarchy list between the two class arguments.
-         */
+        // Returns the list of classes in the class hierarchy from {@code sourceClass} class
+        // to {@code superClass} class, where the first element in the list is {@code sourceClass}.
+        // If the two classes are not in the same hierarchy, {@code null} is returned.
         private List<Class<?>> getClassHierarchy(Class<?> sourceClass, Class<?> superClass) {
 
             if (Object.class.equals(sourceClass)) {
@@ -688,14 +657,7 @@ public class TypeDefinition<T> {
             return null;
         }
 
-        /**
-         * Returns the generic super type of the for the given
-         * {@code sourceClass} matching the specified {@code superClass}.
-         *
-         * @param sourceClass the class containing a generic super type.
-         * @param superClass the non-generic super class of {@code sourceClass}.
-         * @return the generic super type of {@code sourceClass}.
-         */
+        // Returns the generic super type of the for the given {@code sourceClass} matching the specified {@code superClass}.
         private Type getGenericSuperType(Class<?> sourceClass, Class<?> superClass) {
 
             if (superClass.isInterface()) {

--- a/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
+++ b/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
@@ -592,7 +592,10 @@ public class TypeDefinition<T> {
 
             List<Class<?>> classes = getClassHierarchy(sourceClass, superClass);
 
-            List<Class<?>> classesReversed = new ArrayList<>(classes);
+            List<Class<?>> classesReversed = new ArrayList<>();
+            if (classes != null) {
+                classesReversed.addAll(classes);
+            }
             Collections.reverse(classesReversed);
             classesReversed.add(superClass);
 

--- a/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
+++ b/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
@@ -424,6 +424,13 @@ public class TypeDefinitionTest {
         assertEquals(Yellow.class, gigtac(Zero.class, Kappa.class, 0));
     }
 
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_noGenerics() {
+        assertEquals(Charlie.class, gigtac(Bravo.class, Foxtrot.class, 0));
+        assertEquals(Charlie.class, gigtac(Charlie.class, Foxtrot.class, 0));
+        assertEquals(Bravo.class, gigtac(Echo.class, Foxtrot.class, 0));
+    }
+
     // Helper method for test_getInferredGenericTypeArgumentClass* tests
     private Class<?> gigtac(Class<?> sourceClass, Class<?> superClass, int argIndex) {
         return TypeDefinition.getInstance(sourceClass).getInferredGenericTypeArgumentClass(superClass, argIndex);
@@ -477,5 +484,14 @@ public class TypeDefinitionTest {
     private static class Blue extends Purple {
     }
     private static class Purple {
+    }
+
+    private static class Bravo extends Charlie {
+    }
+    private static class Charlie extends Echo {
+    }
+    private static class Echo<T extends Bravo> implements Foxtrot<T> {
+    }
+    private static interface Foxtrot<T extends Charlie> {
     }
 }

--- a/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
+++ b/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import org.junit.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -356,5 +357,125 @@ public class TypeDefinitionTest {
 
         public void setQux(Object qux) {
         }
+    }
+
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_noSuperClass() {
+        assertNull(gigtac(Zero.class, Red.class, 0));
+    }
+
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_noArgIndex() {
+        assertNull(gigtac(Zero.class, Alpha.class, 13));
+    }
+
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_superClasses() {
+        TypeDefinition<Zero> zero = TypeDefinition.getInstance(Zero.class);
+
+        // test super classes
+        Class<?>[] superClasses = { One.class, Two.class, Three.class, Four.class, Five.class, Six.class };
+        Class<?>[][] allExpected = {
+                // class One
+                // A         B             C             D            E           F
+                { Red.class, Orange.class, Yellow.class, Green.class, Blue.class, Purple.class },
+                // class Two
+                // A            B           C            D             E             F          G
+                { Purple.class, Blue.class, Green.class, Yellow.class, Orange.class, Red.class, Red.class },
+                // class Three
+                // A         B          C             D             E            F           G             H
+                { Red.class, Red.class, Orange.class, Yellow.class, Green.class, Blue.class, Purple.class, Orange.class },
+                // class Four
+                // A            B             C           D            E             F             G          H          I
+                { Orange.class, Purple.class, Blue.class, Green.class, Yellow.class, Orange.class, Red.class, Red.class, Yellow.class },
+                // class Five
+                // A            B          C          D             E             F            G           H             I             J
+                { Yellow.class, Red.class, Red.class, Orange.class, Yellow.class, Green.class, Blue.class, Purple.class, Orange.class, Green.class },
+                // class Six
+                // A           B             C             D           E            F             G             H          I          J             K
+                { Green.class, Orange.class, Purple.class, Blue.class, Green.class, Yellow.class, Orange.class, Red.class, Red.class, Yellow.class, Blue.class }
+        };
+
+        int superClassIndex = 0;
+        for (Class<?> superClass : superClasses) {
+
+            Class<?>[] superClassExpected = allExpected[superClassIndex];
+
+            int argIndex = 0;
+            for (Class<?> expected : superClassExpected) {
+                assertEquals(expected, zero.getInferredGenericTypeArgumentClass(superClass, argIndex));
+                argIndex++;
+            }
+
+            superClassIndex++;
+        }
+    }
+
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_interfaces() {
+        assertEquals(Red.class, gigtac(Zero.class, Alpha.class, 0));
+        assertEquals(Blue.class, gigtac(Zero.class, Beta.class, 0));
+        assertEquals(Red.class, gigtac(Zero.class, Gamma.class, 0));
+        assertEquals(Yellow.class, gigtac(Zero.class, Delta.class, 0));
+        assertEquals(Yellow.class, gigtac(Zero.class, Epsilon.class, 0));
+        assertEquals(Yellow.class, gigtac(Zero.class, Zeta.class, 0));
+        assertEquals(Orange.class, gigtac(Zero.class, Eta.class, 0));
+        assertEquals(Green.class, gigtac(Zero.class, Theta.class, 0));
+        assertEquals(Yellow.class, gigtac(Zero.class, Kappa.class, 0));
+    }
+
+    // Helper method for test_getInferredGenericTypeArgumentClass* tests
+    private Class<?> gigtac(Class<?> sourceClass, Class<?> superClass, int argIndex) {
+        return TypeDefinition.getInstance(sourceClass).getInferredGenericTypeArgumentClass(superClass, argIndex);
+    }
+
+    /**
+     * utility code for testing method getInferredGenericTypeArgumentClass()
+     */
+    private static interface Alpha<A> {
+    }
+    private static interface Beta<B> {
+    }
+    private static interface Gamma<G> {
+    }
+    private static interface Delta<D> extends Kappa<D> {
+    }
+    private static interface Epsilon<E> extends Zeta<E> {
+    }
+    private static interface Zeta<Z> {
+    }
+    private static interface Eta<I> {
+    }
+    private static interface Theta<T> {
+    }
+    private static interface Kappa<K> {
+    }
+
+    private static class Zero extends One<Red, Orange, Yellow, Green, Blue, Purple> {
+    }
+    private static class One<A, B, C, D, E, F> extends Two<F, E, D, C, B, A, Red> implements Alpha<A> {
+    }
+    private static class Two<A, B, C, D, E, F, G> extends Three<G, F, E, D, C, B, A, Orange> implements Beta<B>, Gamma<G> {
+    }
+    private static class Three<A, B, C, D, E, F, G, H> extends Four<H, G, F, E, D, C, B, A, Yellow> implements Delta<D> {
+    }
+    private static class Four<A, B, C, D, E, F, G, H, I> extends Five<I, H, G, F, E, D, C, B, A, Green> {
+    }
+    private static class Five<A, B, C, D, E, F, G, H, I, J> extends Six<J, I, H, G, F, E, D, C, B, A, Blue> implements Epsilon<E>, Eta<I> {
+    }
+    private static class Six<A, B, C, D, E, F, G, H, I, J, K> implements Theta<E> {
+    }
+
+    private static class Red<R> extends Orange {
+    }
+    private static class Orange extends Yellow {
+    }
+    private static class Yellow extends Green {
+    }
+    private static class Green extends Blue {
+    }
+    private static class Blue extends Purple {
+    }
+    private static class Purple {
     }
 }


### PR DESCRIPTION
Gets the inferred generic type argument class of the type definition instance type for a given super class (or interface) and its generic type argument index.