### PR TITLE
TypeDefinition#getAllMethods default interface method support

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
+++ b/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
@@ -354,6 +354,10 @@ public class TypeDefinition<T> {
                 methods.addAll(getInstance(superClass).getAllMethods());
             }
 
+            for (Class<?> interfaceClass : objectClass.getInterfaces()) {
+                methods.addAll(getInstance(interfaceClass).getAllMethods());
+            }
+
             return Collections.unmodifiableList(methods);
         }
     };

--- a/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
+++ b/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
@@ -260,6 +260,7 @@ public class TypeDefinitionTest {
         expected.add(Bar.class.getDeclaredMethod("getBar"));
         expected.add(Foo.class.getDeclaredMethod("setFoo", Object.class));
         Collections.addAll(expected, Object.class.getDeclaredMethods());
+        expected.add(Baz.class.getDeclaredMethod("getBaz"));
 
         assertEquals(
                 expected,
@@ -279,6 +280,7 @@ public class TypeDefinitionTest {
         expected.put("qux", Qux.class.getDeclaredMethod("getQux"));
         expected.put("hasQux", Qux.class.getDeclaredMethod("hasQux"));
         expected.put("bar", Bar.class.getDeclaredMethod("getBar"));
+        expected.put("baz", Baz.class.getDeclaredMethod("getBaz"));
 
         assertEquals(
                 expected,
@@ -313,7 +315,14 @@ public class TypeDefinitionTest {
     /**
      * utility code for testing
      */
-    private static class Foo {
+    private static interface Baz {
+
+        default Object getBaz() {
+            return null;
+        }
+    }
+
+    private static class Foo implements Baz {
 
         private static Object staticField;
         private Object _privateField;


### PR DESCRIPTION
Improves TypeDefinition#getAllMethods to include default interface methods introduced in Java 8.