### PR TITLE
Add RecalculationDelay#metricAfterDate.

### DIFF
--- a/db/etc/clirr-ignored.xml
+++ b/db/etc/clirr-ignored.xml
@@ -17,4 +17,10 @@
         <differenceType>7012</differenceType>
         <method>java.util.List findIndexedFields(com.psddev.dari.db.ObjectStruct)</method>
     </difference>
+
+    <difference>
+        <className>com/psddev/dari/db/RecalculationDelay</className>
+        <differenceType>7012</differenceType>
+        <method>org.joda.time.DateTime metricAfterDate(org.joda.time.DateTime)</method>
+    </difference>
 </differences>

--- a/db/src/main/java/com/psddev/dari/db/RecalculationDelay.java
+++ b/db/src/main/java/com/psddev/dari/db/RecalculationDelay.java
@@ -19,6 +19,18 @@ public interface RecalculationDelay {
     boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime);
 
     /**
+     * Returns the {@code DateTime} RecalculateTask uses to find records that
+     * have metric data.
+     *
+     * @param lastRunTime The last execution date of RecalculationTask after
+     *                    having been truncated by the indicated MetricInterval.
+     *                    Never {@code null}.
+     */
+    default DateTime metricAfterDate(DateTime lastRunTime) {
+        return lastRunTime;
+    }
+
+    /**
      * Implementation that recalculates the field value every minute.
      */
     class Minute implements RecalculationDelay {
@@ -26,6 +38,11 @@ public interface RecalculationDelay {
         @Override
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusMinutes(1).isAfter(lastRunTime);
+        }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusMinutes(15);
         }
     }
 
@@ -38,6 +55,11 @@ public interface RecalculationDelay {
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusMinutes(15).isAfter(lastRunTime);
         }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusHours(1);
+        }
     }
 
     /**
@@ -48,6 +70,11 @@ public interface RecalculationDelay {
         @Override
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusMinutes(30).isAfter(lastRunTime);
+        }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusHours(2);
         }
     }
 
@@ -60,6 +87,11 @@ public interface RecalculationDelay {
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusHours(1).isAfter(lastRunTime);
         }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusDays(1);
+        }
     }
 
     /**
@@ -71,6 +103,11 @@ public interface RecalculationDelay {
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusHours(12).isAfter(lastRunTime);
         }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusDays(2);
+        }
     }
 
     /**
@@ -81,6 +118,11 @@ public interface RecalculationDelay {
         @Override
         public boolean isUpdateDue(DateTime currentTime, DateTime lastRunTime) {
             return lastRunTime == null || currentTime.minusDays(1).isAfter(lastRunTime);
+        }
+
+        @Override
+        public DateTime metricAfterDate(DateTime lastRunTime) {
+            return lastRunTime.minusDays(4);
         }
     }
 }

--- a/db/src/main/java/com/psddev/dari/db/RecalculationTask.java
+++ b/db/src/main/java/com/psddev/dari/db/RecalculationTask.java
@@ -164,6 +164,9 @@ public class RecalculationTask extends RepeatingTask {
                     if (interval != null) {
                         processedLastRunDate = new DateTime(interval.process(processedLastRunDate));
                     }
+                    if (context.delay != null) {
+                        processedLastRunDate = context.delay.metricAfterDate(processedLastRunDate);
+                    }
                 }
                 iterator = Metric.Static.getDistinctIdsBetween(Database.Static.getDefault(), null, metricField, processedLastRunDate, null);
 

--- a/db/src/main/java/com/psddev/dari/db/RecalculationTask.java
+++ b/db/src/main/java/com/psddev/dari/db/RecalculationTask.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -172,6 +173,15 @@ public class RecalculationTask extends RepeatingTask {
 
             } else {
                 Query<?> query = Query.fromAll().using(db).noCache().resolveToReferenceOnly().option(SqlDatabase.USE_JDBC_FETCH_SIZE_QUERY_OPTION, false);
+                if (!isGlobal) {
+                    Set<ObjectType> concreteTypes = new HashSet<>();
+                    for (String group : context.groups) {
+                        concreteTypes.addAll(db.getEnvironment().getTypesByGroup(group).stream().filter(ObjectType::isConcrete).collect(Collectors.toSet()));
+                    }
+                    if (!concreteTypes.isEmpty()) {
+                        query.where("_type = ?", concreteTypes);
+                    }
+                }
                 iterator = query.iterable(QUERY_ITERABLE_SIZE).iterator();
             }
 


### PR DESCRIPTION
This calculates the minimum Metric event date used to find the list of
records whose metric values have changed and need to be recalculated. Using
the last processed date as-is is subtly wrong in two scenarios:

1. If the metric value hasn't incremented at all since the last
   recalculation date, recalculation will skip it and the indexed value
   will always reflect the value of the last recalculation

2. If the metric values arrive on a delay, such as with third party
   analytics providers.