### PR TITLE
Fixes StringIndexOutOfBoundsException in StringUtils#toPascalCase.

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/StringUtils.java
+++ b/util/src/main/java/com/psddev/dari/util/StringUtils.java
@@ -231,7 +231,9 @@ public final class StringUtils {
     public static String toPascalCase(String string) {
         StringBuilder nb = new StringBuilder();
         for (String word : splitString(string)) {
-            nb.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+            if (!word.isEmpty()) {
+                nb.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+            }
         }
         return nb.toString();
     }

--- a/util/src/test/java/com/psddev/dari/util/StringUtilsTest.java
+++ b/util/src/test/java/com/psddev/dari/util/StringUtilsTest.java
@@ -236,6 +236,10 @@ public class StringUtilsTest {
 	public void toPascalCase() {
 		assertEquals("AStringWithWords", StringUtils.toPascalCase("a string with words"));
 	}
+	@Test
+	public void toPascalCase_leadingDelimiters() {
+		assertEquals("AStringWithWords", StringUtils.toPascalCase("_a_string_with_words"));
+	}
 	@Test (expected=NullPointerException.class)
 	public void toPascalCase_null() {
 		StringUtils.toPascalCase(null);


### PR DESCRIPTION
Happened when the input string had leading word delimiter characters.