### PR TITLE
BSP-1586; Fixes several issues preventing StorageDebugServlet from copying files properly.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/AsyncStorageItemWriter.java
+++ b/db/src/main/java/com/psddev/dari/db/AsyncStorageItemWriter.java
@@ -146,12 +146,13 @@ public class AsyncStorageItemWriter<E> extends AsyncConsumer<E> {
             }
 
         } else if (value instanceof Map) {
-            for (Map.Entry<?, Object> entry : ((Map<?, Object>) value).entrySet()) {
-                Object item = entry.getValue();
+            Map<String, Object> map = (Map<String, Object>) value;
+            for (String key : new ArrayList<>(map.keySet())) {
+                Object item = map.get(key);
                 if (item instanceof StorageItem) {
                     StorageItem newItem = copyItem((StorageItem) item, source, destination);
                     if (newItem != null) {
-                        entry.setValue(newItem);
+                        map.put(key, newItem);
                         isChanged = true;
                     }
                 } else {

--- a/db/src/main/java/com/psddev/dari/db/StorageDebugServlet.java
+++ b/db/src/main/java/com/psddev/dari/db/StorageDebugServlet.java
@@ -132,7 +132,7 @@ public class StorageDebugServlet extends HttpServlet {
                                 }
                             writeEnd();
                             writeStart("label", "class", "checkbox", "style", "margin-top: 5px;");
-                                writeElement("input", "name", "saveObject", "type", "checkbox");
+                                writeElement("input", "name", "saveObject", "type", "checkbox", "value", "true");
                                 writeHtml("Save object? (slower - consider reusing the original storage name instead)");
                             writeEnd();
                         writeEnd();

--- a/image/src/main/java/com/psddev/dari/util/ImageResizeStorageItemListener.java
+++ b/image/src/main/java/com/psddev/dari/util/ImageResizeStorageItemListener.java
@@ -127,7 +127,7 @@ public class ImageResizeStorageItemListener implements StorageItemListener {
             pathBuilder.append('/');
             pathBuilder.append(parts.get(parts.size() - 1));
 
-            StorageItem dimsItem = StorageItem.Static.create();
+            StorageItem dimsItem = StorageItem.Static.createIn(item.getStorage());
             StorageItem.Static.resetListeners(dimsItem);
 
             dimsItem.setPath(pathBuilder.toString());

--- a/image/src/main/java/com/psddev/dari/util/ImageResizeStorageItemListener.java
+++ b/image/src/main/java/com/psddev/dari/util/ImageResizeStorageItemListener.java
@@ -97,8 +97,6 @@ public class ImageResizeStorageItemListener implements StorageItemListener {
             if (data != null) {
                 data.close();
             }
-
-            item.setData(null);
         }
     }
 

--- a/storage/src/main/java/com/psddev/dari/util/AbstractStorageItem.java
+++ b/storage/src/main/java/com/psddev/dari/util/AbstractStorageItem.java
@@ -1,5 +1,6 @@
 package com.psddev.dari.util;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -280,7 +281,7 @@ public abstract class AbstractStorageItem implements StorageItem {
     @Override
     public InputStream getData() throws IOException {
         if (data == null) {
-            data = createData();
+            data = filterStreamToResetDataOnClose(createData());
         }
         return data;
     }
@@ -290,7 +291,7 @@ public abstract class AbstractStorageItem implements StorageItem {
 
     @Override
     public void setData(InputStream data) {
-        this.data = data;
+        this.data = filterStreamToResetDataOnClose(data);
     }
 
     @Deprecated
@@ -341,7 +342,6 @@ public abstract class AbstractStorageItem implements StorageItem {
         InputStream data = getData();
         try {
             saveData(data);
-            setData(null);
         } finally {
             data.close();
         }
@@ -383,6 +383,24 @@ public abstract class AbstractStorageItem implements StorageItem {
     @Override
     public String toString() {
         return String.format("storageItem:%s:%s", getStorage(), getPath());
+    }
+
+    // sets StorageItem#data to null when the stream is closed so that callers
+    // don't need to explicitly call setData(null) on the StorageItem and
+    // instead can simply follow best practices with regard to reading and
+    // closing streams.
+    private InputStream filterStreamToResetDataOnClose(InputStream stream) {
+        if (stream != null) {
+            return new FilterInputStream(stream) {
+                @Override
+                public void close() throws IOException {
+                    setData(null);
+                    super.close();
+                }
+            };
+        } else {
+            return null;
+        }
     }
 
     // --- Deprecated ---

--- a/storage/src/main/java/com/psddev/dari/util/StorageItem.java
+++ b/storage/src/main/java/com/psddev/dari/util/StorageItem.java
@@ -161,6 +161,7 @@ public interface StorageItem extends SettingsBackedObject {
                 StorageItem newItem = createIn(newStorage);
                 newItem.setPath(item.getPath());
                 newItem.setContentType(item.getContentType());
+                newItem.setMetadata(item.getMetadata());
                 newItem.setData(data);
                 newItem.save();
                 return newItem;


### PR DESCRIPTION
Fixes saveObject checkbox not getting processed on form submission in the StorageDebugServlet. The saveObject checkbox did not have a value set, and browsers like chrome default the value to "on" instead of the expected value of "true".

Fixes State map not getting properly updated when copying StorageItems. This is a workaround for a different bug with the State#entrySet / State.Entry#setValue API where calling setValue does not properly update the State and a subsequent call to State#save would lose any changes made. The workaround is to loop over the State#keySet and just call State#put directly.

Fixes metadata not getting copied in StorageItem.Static#copy API. This originated from the StorageItem.Static#copy API not getting updated when the concept of StorageItem metadata was later introduced. History can be traced in the pre open source dari commit: fa259690d3d843184a8a7bdee21d8393e69dbd01

Fixes resizes being created in default storage instead of the parent's. StorageItem resizes should honor the storage settings of its parent.

Wraps the stream returned from StorageItem#getData to automatically reset the StorageItem#data field on close. The wrapper stream implementation sets StorageItem#data to null when the stream is closed so that callers don't need to explicitly call setData(null) on the StorageItem and instead can simply follow best practices with regard to reading and closing streams.