### PR TITLE
Changes SqlQuery to skip the IGNORE INDEX (PRIMARY) hint when appropriate.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/SqlQuery.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlQuery.java
@@ -57,6 +57,7 @@ class SqlQuery {
     private Join mysqlIndexHint;
     private boolean mysqlIgnoreIndexPrimaryDisabled;
     private boolean forceLeftJoins;
+    private boolean allNotEqualsAll;
 
     private final List<Predicate> recordMetricDatePredicates = new ArrayList<Predicate>();
     private final List<Predicate> recordMetricParentDatePredicates = new ArrayList<Predicate>();
@@ -644,6 +645,7 @@ class SqlQuery {
             boolean hasMissing = false;
             int subClauseCount = 0;
             boolean isNotEqualsAll = PredicateParser.NOT_EQUALS_ALL_OPERATOR.equals(operator);
+            allNotEqualsAll |= isNotEqualsAll;
 
             if (isNotEqualsAll || PredicateParser.EQUALS_ANY_OPERATOR.equals(operator)) {
                 Query<?> valueQuery = mappedKey.getSubQueryWithComparison(comparisonPredicate);
@@ -1603,6 +1605,7 @@ class SqlQuery {
 
         if (fromClause.length() > 0
                 && !fromClause.contains("LEFT OUTER JOIN")
+                && !allNotEqualsAll
                 && !mysqlIgnoreIndexPrimaryDisabled) {
             statementBuilder.append(" /*! IGNORE INDEX (PRIMARY) */");
         }

--- a/db/src/main/java/com/psddev/dari/db/SqlQuery.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlQuery.java
@@ -57,7 +57,7 @@ class SqlQuery {
     private Join mysqlIndexHint;
     private boolean mysqlIgnoreIndexPrimaryDisabled;
     private boolean forceLeftJoins;
-    private boolean allNotEqualsAll;
+    private boolean hasAnyLimitingPredicates;
 
     private final List<Predicate> recordMetricDatePredicates = new ArrayList<Predicate>();
     private final List<Predicate> recordMetricParentDatePredicates = new ArrayList<Predicate>();
@@ -645,7 +645,9 @@ class SqlQuery {
             boolean hasMissing = false;
             int subClauseCount = 0;
             boolean isNotEqualsAll = PredicateParser.NOT_EQUALS_ALL_OPERATOR.equals(operator);
-            allNotEqualsAll |= isNotEqualsAll;
+            if (!isNotEqualsAll) {
+                hasAnyLimitingPredicates = true;
+            }
 
             if (isNotEqualsAll || PredicateParser.EQUALS_ANY_OPERATOR.equals(operator)) {
                 Query<?> valueQuery = mappedKey.getSubQueryWithComparison(comparisonPredicate);
@@ -1605,7 +1607,7 @@ class SqlQuery {
 
         if (fromClause.length() > 0
                 && !fromClause.contains("LEFT OUTER JOIN")
-                && !allNotEqualsAll
+                && hasAnyLimitingPredicates
                 && !mysqlIgnoreIndexPrimaryDisabled) {
             statementBuilder.append(" /*! IGNORE INDEX (PRIMARY) */");
         }


### PR DESCRIPTION
See: da721bd. If any predicate limits the resultset, it is more
efficient to meet those conditions before pulling in the typeId. If all
of the predicates are NOT IN or != or IS NOT NULL, the resultset is
still effectively unlimited, and the PRIMARY key is the optimal
execution plan.