### PR TITLE
added EnterpriseDB to sql vendor class map

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlDatabase.java
@@ -238,6 +238,7 @@ public class SqlDatabase extends AbstractDatabase<Connection> {
         m.put("H2", SqlVendor.H2.class);
         m.put("MySQL", SqlVendor.MySQL.class);
         m.put("PostgreSQL", SqlVendor.PostgreSQL.class);
+        m.put("EnterpriseDB", SqlVendor.PostgreSQL.class);
         m.put("Oracle", SqlVendor.Oracle.class);
         VENDOR_CLASSES = m;
     }


### PR DESCRIPTION
Brightspot fails to start as mastercard are using an enterprise version of Postgres.
This PR fixes the issue (Thx Lee) by adding an entry for "EnterpriseDB" to the map.