### PR TITLE
Prevent ReferentialText resolution chain

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/ReferentialText.java
+++ b/db/src/main/java/com/psddev/dari/db/ReferentialText.java
@@ -496,7 +496,7 @@ public class ReferentialText extends AbstractList<Object> {
 
     // --- AbstractList support ---
 
-    protected final Object checkItem(Object item) {
+    protected Object checkItem(Object item) {
         Preconditions.checkNotNull(item);
 
         if (item instanceof Reference) {

--- a/db/src/main/java/com/psddev/dari/db/ReferentialText.java
+++ b/db/src/main/java/com/psddev/dari/db/ReferentialText.java
@@ -29,7 +29,7 @@ public class ReferentialText extends AbstractList<Object> {
     private static final Tag DIV_TAG = Tag.valueOf("div");
     private static final Tag P_TAG = Tag.valueOf("p");
 
-    private final List<Object> list = new ArrayList<Object>();
+    protected final List<Object> list = new ArrayList<Object>();
 
     /**
      * Creates an empty instance.
@@ -485,7 +485,7 @@ public class ReferentialText extends AbstractList<Object> {
 
     // --- AbstractList support ---
 
-    private Object checkItem(Object item) {
+    protected final Object checkItem(Object item) {
         Preconditions.checkNotNull(item);
 
         if (item instanceof Reference) {
@@ -552,5 +552,35 @@ public class ReferentialText extends AbstractList<Object> {
         public void before(Element body);
 
         public void after(Element body);
+    }
+
+    /**
+     * A lazy-loaded implementation of ReferentialText that checks items when they are accessed instead of when they
+     * are inserted. This defers reference resolution.
+     */
+    public static class Lazy extends ReferentialText {
+
+        @Override
+        public void add(int index, Object item) {
+            list.add(index, item);
+        }
+
+        @Override
+        public Object get(int index) {
+            Object item = checkItem(list.get(index));
+            list.set(index, item);
+            return item;
+        }
+
+        @Override
+        public Object remove(int index) {
+            return checkItem(list.remove(index));
+        }
+
+        @Override
+        public Object set(int index, Object item) {
+            return list.set(index, item);
+        }
+
     }
 }

--- a/db/src/main/java/com/psddev/dari/db/StateValueUtils.java
+++ b/db/src/main/java/com/psddev/dari/db/StateValueUtils.java
@@ -497,7 +497,8 @@ abstract class StateValueUtils {
                     return value;
 
                 } else {
-                    ReferentialText text = new ReferentialText();
+                    //Use a lazy ReferentialText to defer resolution
+                    ReferentialText text = new ReferentialText.Lazy();
 
                     if (value instanceof Iterable) {
                         boolean isFirst = false;


### PR DESCRIPTION
When a ReferentialText field is loaded in by StateValueUtils, it immediately goes through each of the items in the ReferentialText and calls checkItem() which triggers immediate reference resolution.  This is a problem if the object being resolved also has a ReferentialText field, because it triggers an immediate chain of resolution.

This change changes StateValueUtils to use a lazy-loading ReferentialText implementation that resolves references when they are accessed rather than when they are added.