### PR TITLE
Fix Java Image Editor bug when used with OpenJDK 8

### DIFF
--- a/image/src/main/java/com/psddev/dari/util/JavaImageServlet.java
+++ b/image/src/main/java/com/psddev/dari/util/JavaImageServlet.java
@@ -451,7 +451,7 @@ public class JavaImageServlet extends HttpServlet {
             ImageIO.write(bufferedImage, imageType, out);
 
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            ImageIO.write(bufferedImage, "jpg", byteArrayOutputStream);
+            ImageIO.write(bufferedImage, imageType, byteArrayOutputStream);
             byteArrayOutputStream.flush();
             byte[] data = byteArrayOutputStream.toByteArray();
 


### PR DESCRIPTION
OpenJDK 8 fails with the error "javax.imageio.IIOException: Invalid
argument to native writeImage" when an PNG with transparency is
resized. This appears to be because it tries to generate a JPG with
transparency for the hash value which is not supported in OpenJDK 8.