### PR TITLE
BSP-2218: Fixes to use protocol agnostic url in HtmlApiFilter

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/HtmlApiFilter.java
+++ b/util/src/main/java/com/psddev/dari/util/HtmlApiFilter.java
@@ -61,7 +61,7 @@ public class HtmlApiFilter extends AbstractFilter {
                 writer.write("f.style.border = 'none';");
                 writer.write("f.style.width = '100%';");
                 writer.write("f.src = '");
-                writer.write(StringUtils.escapeJavaScript(JspUtils.getAbsoluteUrl(request, "", "_format", "_frame")));
+                writer.write(StringUtils.escapeJavaScript(JspUtils.getAbsoluteProtocolRelativeUrl(request, "", "_format", "_frame")));
                 writer.write("';");
 
                 writer.write("s.parentNode.insertBefore(f, s);");
@@ -93,7 +93,7 @@ public class HtmlApiFilter extends AbstractFilter {
                         "padding", 0));
                     html.writeStart("iframe",
                             "scrolling", "no",
-                            "src", JspUtils.getAbsoluteUrl(request, "", "_format", null),
+                            "src", JspUtils.getAbsoluteProtocolRelativeUrl(request, "", "_format", null),
                             "style", html.cssString(
                                     "border", "none",
                                     "width", "100%"));
@@ -156,7 +156,7 @@ public class HtmlApiFilter extends AbstractFilter {
 
             html.writeStart("script",
                     "type", "text/javascript",
-                    "src", JspUtils.getAbsoluteUrl(request, "", "_format", "js"));
+                    "src", JspUtils.getAbsoluteProtocolRelativeUrl(request, "", "_format", "js"));
             html.writeEnd();
 
             json.put("version", "1.0");

--- a/util/src/main/java/com/psddev/dari/util/JspUtils.java
+++ b/util/src/main/java/com/psddev/dari/util/JspUtils.java
@@ -1103,7 +1103,7 @@ public final class JspUtils {
             String url,
             Object... parameters) {
 
-        return getHostUrl(request) + getAbsolutePath(context, request, url, parameters);
+        return getHostUrl(request) + getEmbeddedAbsolutePath(context, request, url, parameters);
     }
 
     /** Returns the absolute protocol relative version of the given {@code url}. */
@@ -1113,7 +1113,7 @@ public final class JspUtils {
             String url,
             Object... parameters) {
 
-        return getProtocolRelativeHostUrl(request) + getAbsolutePath(context, request, url, parameters);
+        return getProtocolRelativeHostUrl(request) + getEmbeddedAbsolutePath(context, request, url, parameters);
     }
 
     /**
@@ -1224,7 +1224,7 @@ public final class JspUtils {
 
         response = (HttpServletResponse) getHeaderResponse(request, response);
         response.setStatus(status);
-        response.setHeader("Location", response.encodeRedirectURL(getAbsolutePath(context, request, path == null ? null : path.toString(), parameters)));
+        response.setHeader("Location", response.encodeRedirectURL(getEmbeddedAbsolutePath(context, request, path == null ? null : path.toString(), parameters)));
     }
 
     /**

--- a/util/src/main/java/com/psddev/dari/util/JspUtils.java
+++ b/util/src/main/java/com/psddev/dari/util/JspUtils.java
@@ -277,6 +277,15 @@ public final class JspUtils {
         return getEmbeddedAbsoluteUrl(null, request, url, parameters);
     }
 
+    /** Returns the absolute protocol relative version of the given {@code url}. */
+    public static String getAbsoluteProtocolRelativeUrl(
+            HttpServletRequest request,
+            String url,
+            Object... parameters) {
+
+        return getEmbeddedAbsoluteProtocolRelativeUrl(null, request, url, parameters);
+    }
+
     /**
      * Returns the cookie with the given {@code name} from the given
      * {@code request}.


### PR DESCRIPTION
One downside of this approach is that embed code cannot be used in local file for testing as it will use `file` scheme.
Please let me know if it's better to specify http(s) protocol.