### PR TITLE
Debug Code Editor: Try to execute a method named main first

### DIFF
--- a/util/src/main/java/com/psddev/dari/util/CodeUtils.java
+++ b/util/src/main/java/com/psddev/dari/util/CodeUtils.java
@@ -444,14 +444,14 @@ public final class CodeUtils {
                         && method.getParameterTypes().length == 0
                     )
                     .collect(Collectors.toList());
-                
+
                 Method chosenOne = declaredMethods
                     .stream()
                     .filter(method -> "main".equals(method.getName()))
                     .findAny()
                     .orElseGet(() -> declaredMethods.stream().findAny().orElse(null));
-                
-                if(chosenOne != null) {
+
+                if (chosenOne != null) {
                     chosenOne.setAccessible(true);
                     try {
                         return chosenOne.invoke(null);


### PR DESCRIPTION
When executing code in the `_debug/code` tool, the method being executed is very random if there's more than one static method with no parameters (even if only one of them is public!).

This PR tries first to execute a method named `main`, otherwise a random one is executed (as before).