### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/AbstractDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/AbstractDatabase.java
@@ -888,10 +888,6 @@ public abstract class AbstractDatabase<C> implements Database {
     }
 
     @Override
-    public void indexAll(ObjectIndex index) {
-    }
-
-    @Override
     public void recalculate(State state, ObjectIndex... indexes) {
         checkState(state);
         Writes writes = getCurrentWrites();
@@ -924,27 +920,6 @@ public abstract class AbstractDatabase<C> implements Database {
 
         } else {
             write(null, null, null, Arrays.asList(state), null, true);
-        }
-    }
-
-    @Override
-    public void deleteByQuery(Query<?> query) {
-        int batchSize = 200;
-        try {
-            beginWrites();
-
-            int i = 0;
-            for (Object item : readIterable(query, batchSize)) {
-                delete(State.getInstance(item));
-                ++ i;
-                if (i % batchSize == 0) {
-                    commitWrites();
-                }
-            }
-
-            commitWrites();
-        } finally {
-            endWrites();
         }
     }
 

--- a/db/src/main/java/com/psddev/dari/db/AbstractGrouping.java
+++ b/db/src/main/java/com/psddev/dari/db/AbstractGrouping.java
@@ -36,12 +36,6 @@ public abstract class AbstractGrouping<T> implements Grouping<T>, HtmlObject {
         return itemsQuery;
     }
 
-    @Deprecated
-    @Override
-    public Query<T> getItemsQuery() {
-        return createItemsQuery();
-    }
-
     protected abstract Aggregate createAggregate(String field);
 
     private Aggregate getAggregate(String field) {

--- a/db/src/main/java/com/psddev/dari/db/Database.java
+++ b/db/src/main/java/com/psddev/dari/db/Database.java
@@ -202,13 +202,32 @@ public interface Database extends SettingsBackedObject {
     }
 
     /** Ensures that given {@code index} is up-to-date across all states. */
-    public void indexAll(ObjectIndex index);
+    public default void indexAll(ObjectIndex index) {
+	}
 
     /** Deletes the given {@code state}. */
     public void delete(State state);
 
     /** Deletes all objects matching the given {@code query}. */
-    public void deleteByQuery(Query<?> query);
+    public default void deleteByQuery(Query<?> query) {
+	    int batchSize = 200;
+	    try {
+	        beginWrites();
+	
+	        int i = 0;
+	        for (Object item : readIterable(query, batchSize)) {
+	            delete(State.getInstance(item));
+	            ++ i;
+	            if (i % batchSize == 0) {
+	                commitWrites();
+	            }
+	        }
+	
+	        commitWrites();
+	    } finally {
+	        endWrites();
+	    }
+	}
 
     default void addUpdateNotifier(UpdateNotifier<?> notifier) {
         throw new UnsupportedOperationException();

--- a/db/src/main/java/com/psddev/dari/db/Grouping.java
+++ b/db/src/main/java/com/psddev/dari/db/Grouping.java
@@ -10,7 +10,9 @@ public interface Grouping<T> {
 
     /** Use {@link #createItemsQuery} instead. */
     @Deprecated
-    public Query<T> getItemsQuery();
+    public default Query<T> getItemsQuery() {
+	    return createItemsQuery();
+	}
 
     public long getCount();
 

--- a/db/src/main/java/com/psddev/dari/db/SqlIndex.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlIndex.java
@@ -189,7 +189,9 @@ public enum SqlIndex {
 
         public int getVersion();
 
-        public boolean isReadOnly(ObjectIndex index);
+        public default boolean isReadOnly(ObjectIndex index) {
+		    return false;
+		}
 
         public String getName(SqlDatabase database, ObjectIndex index);
 
@@ -205,7 +207,9 @@ public enum SqlIndex {
             return convertKey(database, index, key);
         }
 
-        public Object convertKey(SqlDatabase database, ObjectIndex index, String key);
+        public default Object convertKey(SqlDatabase database, ObjectIndex index, String key) {
+		    return key;
+		}
 
         public String prepareInsertStatement(
                 SqlDatabase database,
@@ -262,11 +266,6 @@ public enum SqlIndex {
         }
 
         @Override
-        public boolean isReadOnly(ObjectIndex index) {
-            return false;
-        }
-
-        @Override
         public String getIdField(SqlDatabase database, ObjectIndex index) {
             return idField;
         }
@@ -306,11 +305,6 @@ public enum SqlIndex {
             }
 
             return fieldIndex > 0 ? valueField + (fieldIndex + 1) : valueField;
-        }
-
-        @Override
-        public Object convertKey(SqlDatabase database, ObjectIndex index, String key) {
-            return key;
         }
 
         protected Object convertValue(SqlDatabase database, ObjectIndex index, int fieldIndex, Object value) {

--- a/storage/src/main/java/com/psddev/dari/util/AbstractStorageItem.java
+++ b/storage/src/main/java/com/psddev/dari/util/AbstractStorageItem.java
@@ -294,17 +294,6 @@ public abstract class AbstractStorageItem implements StorageItem {
         this.data = filterStreamToResetDataOnClose(data);
     }
 
-    @Deprecated
-    @Override
-    public URL getUrl() {
-        String url = getPublicUrl();
-        try {
-            return new URL(url);
-        } catch (MalformedURLException ex) {
-            throw new IllegalStateException(String.format("[%s] is not a valid URL!", url));
-        }
-    }
-
     @Override
     public String getPublicUrl() {
         return createPublicUrl(getBaseUrl(), getPath());

--- a/storage/src/main/java/com/psddev/dari/util/StorageItem.java
+++ b/storage/src/main/java/com/psddev/dari/util/StorageItem.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -78,7 +79,14 @@ public interface StorageItem extends SettingsBackedObject {
      * @deprecated Use {@link #getPublicUrl} instead.
      */
     @Deprecated
-    public URL getUrl();
+    public default URL getUrl() {
+	    String url = getPublicUrl();
+	    try {
+	        return new URL(url);
+	    } catch (MalformedURLException ex) {
+	        throw new IllegalStateException(String.format("[%s] is not a valid URL!", url));
+	    }
+	}
 
     /** Returns the URL for accessing this item publicly. */
     public String getPublicUrl();


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.