### PR TITLE
BSP-2438 Changes ColorImageData#beforeSave to beforeCommit

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/ColorImage.java
+++ b/db/src/main/java/com/psddev/dari/db/ColorImage.java
@@ -27,7 +27,7 @@ class ColorImageData extends Modification<ColorImage> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorImageData.class);
 
     @Override
-    protected void beforeSave() {
+    protected void beforeCommit() {
         ColorDistribution.Data distributionData = as(ColorDistribution.Data.class);
 
         if (distributionData.getDistribution() == null) {


### PR DESCRIPTION
Prevents excessive calls by upstream processes.