### PR TITLE
BSP-1678: Hack to remove artifactId in SCM URLs.

### DIFF
--- a/grandparent/pom.xml
+++ b/grandparent/pom.xml
@@ -109,6 +109,7 @@
                             <source><![CDATA[
 import java.io.*
 import java.util.*
+import java.util.regex.*
 
 def packaging = project.packaging
 if (!(packaging == 'jar' || packaging == 'war')) {
@@ -133,9 +134,10 @@ try {
 
     def scm = project.scm
     if (scm) {
-        map['scmConnection'] = scm.connection
-        map['scmDeveloperConnection'] = scm.developerConnection
-        map['scmUrl'] = scm.url
+        def suffix = '\\.git/.*$'
+        map['scmConnection'] = scm.connection?.replaceFirst(suffix, '.git')
+        map['scmDeveloperConnection'] = scm.developerConnection?.replaceFirst(suffix, '.git')
+        map['scmUrl'] = scm.url?.replaceFirst(suffix, '.git')
     }
 
     map['classFinder.include'] = 'true'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MPIR-234