### PR TITLE
BSP-1212: Upgrades shyiko mysql replication library to 0.4.2.

### DIFF
--- a/db/pom.xml
+++ b/db/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.github.shyiko</groupId>
             <artifactId>mysql-binlog-connector-java</artifactId>
-            <version>0.1.0</version>
+            <version>0.4.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is mainly to pick up
https://github.com/shyiko/mysql-binlog-connector-java/commit/7efa961867b
55284bb9bf7932f63a4536fe55da3 fix.