### PR TITLE
BSP-2801 Makes State#resolveReference Thread-safe

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/LazyLoadEnhancer.java
+++ b/db/src/main/java/com/psddev/dari/db/LazyLoadEnhancer.java
@@ -61,7 +61,8 @@ public class LazyLoadEnhancer extends ClassEnhancer {
     public boolean canEnhance(ClassReader reader) {
         enhancedClassName = reader.getClassName();
 
-        return !enhancedClassName.startsWith("com/psddev/dari/")
+        return (!enhancedClassName.startsWith("com/psddev/dari/")
+                || enhancedClassName.startsWith("com/psddev/dari/h2/"))
                 && findRecordableClass(enhancedClassName) != null;
     }
 

--- a/db/src/main/java/com/psddev/dari/db/State.java
+++ b/db/src/main/java/com/psddev/dari/db/State.java
@@ -1633,7 +1633,6 @@ public class State implements Map<String, Object> {
         */
 
         synchronized (this) {
-
             if ((flags & ALL_RESOLVED_FLAG) != 0) {
                 return;
             }

--- a/db/src/main/java/com/psddev/dari/db/State.java
+++ b/db/src/main/java/com/psddev/dari/db/State.java
@@ -1676,7 +1676,7 @@ public class State implements Map<String, Object> {
                 for (Map.Entry<String, Object> e : resolved.entrySet()) {
                     put(e.getKey(), e.getValue());
                 }
-                
+
                 flags |= ALL_RESOLVED_FLAG;
 
             } finally {

--- a/db/src/main/java/com/psddev/dari/db/State.java
+++ b/db/src/main/java/com/psddev/dari/db/State.java
@@ -1637,8 +1637,6 @@ public class State implements Map<String, Object> {
                 return;
             }
 
-            flags |= ALL_RESOLVED_FLAG;
-
             if (linkedObjects.isEmpty()) {
                 return;
             }
@@ -1680,6 +1678,8 @@ public class State implements Map<String, Object> {
             } finally {
                 Profiler.Static.stopThreadEvent();
             }
+
+            flags |= ALL_RESOLVED_FLAG;
         }
     }
 

--- a/db/src/main/java/com/psddev/dari/db/State.java
+++ b/db/src/main/java/com/psddev/dari/db/State.java
@@ -1634,56 +1634,52 @@ public class State implements Map<String, Object> {
 
         synchronized (this) {
 
+            if ((flags & ALL_RESOLVED_FLAG) != 0) {
+                return;
+            }
+
+            if (linkedObjects.isEmpty()) {
+                flags |= ALL_RESOLVED_FLAG;
+                return;
+            }
+
+            boolean hasPotentialRefs = false;
+            Collection<Object> rawValuesValues = rawValues.values();
+
+            for (Object rawValue : rawValuesValues) {
+                if (rawValue instanceof Map
+                        && ((Map<?, ?>) rawValue).containsKey(StateSerializer.REFERENCE_KEY)) {
+                    hasPotentialRefs = true;
+                    break;
+                }
+            }
+
+            if (!hasPotentialRefs) {
+                flags |= ALL_RESOLVED_FLAG;
+                return;
+            }
+
+            Profiler.Static.startThreadEvent(RESOLVE_REFERENCE_PROFILER_EVENT, this);
+
             try {
+                Object object = linkedObjects.values().iterator().next();
+                Map<UUID, Object> references = StateValueUtils.resolveReferences(getDatabase(), object, rawValuesValues, field);
+                Map<String, Object> resolved = new HashMap<>();
+                resolveMetricReferences(resolved);
 
-                if ((flags & ALL_RESOLVED_FLAG) != 0) {
-                    return;
-                }
-
-                if (linkedObjects.isEmpty()) {
-                    return;
-                }
-
-                boolean hasPotentialRefs = false;
-                Collection<Object> rawValuesValues = rawValues.values();
-
-                for (Object rawValue : rawValuesValues) {
-                    if (rawValue instanceof Map
-                            && ((Map<?, ?>) rawValue).containsKey(StateSerializer.REFERENCE_KEY)) {
-                        hasPotentialRefs = true;
-                        break;
+                for (Map.Entry<? extends String, ?> e : rawValues.entrySet()) {
+                    UUID id = StateValueUtils.toIdIfReference(e.getValue());
+                    if (id != null) {
+                        resolved.put(e.getKey(), references.get(id));
                     }
                 }
 
-                if (!hasPotentialRefs) {
-                    return;
-                }
-
-                Profiler.Static.startThreadEvent(RESOLVE_REFERENCE_PROFILER_EVENT, this);
-
-                try {
-                    Object object = linkedObjects.values().iterator().next();
-                    Map<UUID, Object> references = StateValueUtils.resolveReferences(getDatabase(), object, rawValuesValues, field);
-                    Map<String, Object> resolved = new HashMap<>();
-                    resolveMetricReferences(resolved);
-
-                    for (Map.Entry<? extends String, ?> e : rawValues.entrySet()) {
-                        UUID id = StateValueUtils.toIdIfReference(e.getValue());
-                        if (id != null) {
-                            resolved.put(e.getKey(), references.get(id));
-                        }
-                    }
-
-                    for (Map.Entry<String, Object> e : resolved.entrySet()) {
-                        put(e.getKey(), e.getValue());
-                    }
-
-                } finally {
-                    Profiler.Static.stopThreadEvent();
+                for (Map.Entry<String, Object> e : resolved.entrySet()) {
+                    put(e.getKey(), e.getValue());
                 }
 
             } finally {
-                flags |= ALL_RESOLVED_FLAG;
+                Profiler.Static.stopThreadEvent();
             }
         }
     }

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -97,7 +97,7 @@
                             <goal>java</goal>
                         </goals>
                         <configuration>
-                            <classpathScope>compile</classpathScope>
+                            <classpathScope>test</classpathScope>
                             <includePluginDependencies>true</includePluginDependencies>
                             <mainClass>com.psddev.dari.util.ClassEnhancer$Static</mainClass>
                             <arguments>

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -74,4 +74,39 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>com.psddev</groupId>
+                        <artifactId>dari-util</artifactId>
+                        <version>3.2-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
+
+                <executions>
+                    <execution>
+                        <id>enhance-test-classes</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <classpathScope>compile</classpathScope>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <mainClass>com.psddev.dari.util.ClassEnhancer$Static</mainClass>
+                            <arguments>
+                                <argument>${project.build.testOutputDirectory}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/h2/src/test/java/com/psddev/dari/h2/StateTest.java
+++ b/h2/src/test/java/com/psddev/dari/h2/StateTest.java
@@ -1,0 +1,80 @@
+package com.psddev.dari.h2;
+
+import com.psddev.dari.db.Query;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+import static org.junit.Assert.*;
+
+public class StateTest extends AbstractTest {
+
+    @After
+    public void deleteModels() {
+
+        Query.from(UuidIndexModel.class).deleteAll();
+    }
+
+    @Test
+    public void concurrentResolveReferences() throws Exception {
+
+        int numThreads = 20;
+
+        UuidIndexModel model1 = new UuidIndexModel();
+        UuidIndexModel model2 = new UuidIndexModel();
+        model1.setReferenceOne(model2);
+
+        model1.save();
+        model2.save();
+
+        final UuidIndexModel dbModel1 = Query.from(UuidIndexModel.class).noCache().master().where("_id = ?", model1).first();
+
+        final CyclicBarrier gate = new CyclicBarrier(numThreads);
+
+        final CyclicBarrier end = new CyclicBarrier(numThreads + 1);
+
+        List<Thread> threads = new ArrayList<>();
+
+        final List<Object> references = Collections.synchronizedList(new ArrayList<>());
+        final List<String> errors = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < numThreads; i += 1) {
+            threads.add(new Thread(() -> {
+
+                try {
+                    gate.await();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    errors.add(e.getClass().getName() + ": " + e.getMessage());
+                    return;
+                }
+
+                references.add(dbModel1.getReferenceOne());
+
+                try {
+                    end.await();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    errors.add(e.getClass().getName() + ": " + e.getMessage());
+                    return;
+                }
+            }));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        end.await();
+
+        if (errors.size() > 0) {
+            errors.forEach(System.out::println);
+            throw new Exception("Encountered " + errors.size() + " concurrency errors during test!");
+        }
+
+        assertTrue(!references.stream().anyMatch(o -> o == null));
+    }
+}

--- a/h2/src/test/java/com/psddev/dari/h2/StateTest.java
+++ b/h2/src/test/java/com/psddev/dari/h2/StateTest.java
@@ -32,16 +32,13 @@ public class StateTest extends AbstractTest {
         model1.save();
         model2.save();
 
-        final UuidIndexModel dbModel1 = Query.from(UuidIndexModel.class).noCache().master().where("_id = ?", model1).first();
-
-        final CyclicBarrier gate = new CyclicBarrier(numThreads);
-
-        final CyclicBarrier end = new CyclicBarrier(numThreads + 1);
-
         List<Thread> threads = new ArrayList<>();
-
+        final CyclicBarrier gate = new CyclicBarrier(numThreads);
+        final CyclicBarrier end = new CyclicBarrier(numThreads + 1);
         final List<Object> references = Collections.synchronizedList(new ArrayList<>());
         final List<String> errors = Collections.synchronizedList(new ArrayList<>());
+
+        final UuidIndexModel dbModel1 = Query.from(UuidIndexModel.class).noCache().master().where("_id = ?", model1.getId()).first();
 
         for (int i = 0; i < numThreads; i += 1) {
             threads.add(new Thread(() -> {
@@ -53,7 +50,9 @@ public class StateTest extends AbstractTest {
                     return;
                 }
 
-                references.add(dbModel1.getReferenceOne());
+                UuidIndexModel dbModel1ReferenceOne = dbModel1.getReferenceOne();
+
+                references.add(dbModel1ReferenceOne);
 
                 try {
                     end.await();


### PR DESCRIPTION
BSP-2801 changes location of expression to set ALL_RESOLVED_FLAG so that a second Thread executing State#resolveReference will be forced to wait at the synchronized block until the first Thread has completed resolving references.