### PR TITLE
BSP-469 - Allows classes that extend Modification to also have subclasses

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/Modification.java
+++ b/db/src/main/java/com/psddev/dari/db/Modification.java
@@ -5,10 +5,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import com.psddev.dari.util.TypeDefinition;
 
 /**
  * Modifies the {@linkplain ObjectType object type} definitions that are
@@ -103,24 +103,10 @@ class Bar extends Modification&lt;Object&gt; { ... }</pre></blockquote>
                 }
             }
 
-            Type superClass = modificationClass.getGenericSuperclass();
+            Class<?> genericTypeClass = TypeDefinition.getInstance(modificationClass).getInferredGenericTypeArgumentClass(Modification.class, 0);
 
-            if (superClass instanceof ParameterizedType) {
-                Type[] typeArguments = ((ParameterizedType) superClass).getActualTypeArguments();
-
-                if (typeArguments != null && typeArguments.length > 0) {
-                    Type type = typeArguments[0];
-
-                    while (true) {
-                        if (type instanceof Class) {
-                            modified.add((Class<?>) type);
-                        } else if (type instanceof ParameterizedType) {
-                            type = ((ParameterizedType) type).getRawType();
-                            continue;
-                        }
-                        break;
-                    }
-                }
+            if (genericTypeClass != null) {
+                modified.add(genericTypeClass);
             }
 
             if (modified.isEmpty()) {

--- a/db/src/main/java/com/psddev/dari/db/Recordable.java
+++ b/db/src/main/java/com/psddev/dari/db/Recordable.java
@@ -165,6 +165,7 @@ public interface Recordable {
      * target type.
      */
     @Documented
+    @Inherited
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface FieldInternalNamePrefix {

--- a/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
+++ b/util/src/main/java/com/psddev/dari/util/TypeDefinition.java
@@ -544,6 +544,13 @@ public class TypeDefinition<T> {
                     if (superClassTypeVar instanceof Class) {
                         return (Class<?>) superClassTypeVar;
 
+                    } else if (superClassTypeVar instanceof ParameterizedType) {
+                        Type rawType = ((ParameterizedType) superClassTypeVar).getRawType();
+
+                        if (rawType instanceof Class) {
+                            return (Class<?>) rawType;
+                        }
+
                     } else if (superClassTypeVar instanceof TypeVariable) {
 
                         Class<?> hierarchyClass = entry.getKey();

--- a/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
+++ b/util/src/test/java/com/psddev/dari/util/TypeDefinitionTest.java
@@ -431,6 +431,11 @@ public class TypeDefinitionTest {
         assertEquals(Bravo.class, gigtac(Echo.class, Foxtrot.class, 0));
     }
 
+    @Test
+    public void test_getInferredGenericTypeArgumentClass_parameterizedArgument() {
+        assertEquals(List.class, gigtac(Seven.class, Alpha.class, 0));
+    }
+
     // Helper method for test_getInferredGenericTypeArgumentClass* tests
     private Class<?> gigtac(Class<?> sourceClass, Class<?> superClass, int argIndex) {
         return TypeDefinition.getInstance(sourceClass).getInferredGenericTypeArgumentClass(superClass, argIndex);
@@ -471,6 +476,8 @@ public class TypeDefinitionTest {
     private static class Five<A, B, C, D, E, F, G, H, I, J> extends Six<J, I, H, G, F, E, D, C, B, A, Blue> implements Epsilon<E>, Eta<I> {
     }
     private static class Six<A, B, C, D, E, F, G, H, I, J, K> implements Theta<E> {
+    }
+    private static class Seven implements Alpha<List<String>> {
     }
 
     private static class Red<R> extends Orange {


### PR DESCRIPTION
Also:
* Fixes a bug with `TypeDefinition#getInferredGenericTypeArgumentClass` API where it could incorrectly return null in some scenarios. Adds test case.
* Marks `@FieldInternalNamePrefix` as an `@Inherited` annotation.