### PR TITLE
Circles fix for Region object - needs to create new array when using …

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/Region.java
+++ b/db/src/main/java/com/psddev/dari/db/Region.java
@@ -70,6 +70,7 @@ public class Region {
         this.y = y;
         this.radius = radius;
         this.polygons = polygons;
+        this.circles = new ArrayList<>();
     }
 
     /**
@@ -181,6 +182,18 @@ public class Region {
 
     public Double getRadius() {
         return radius;
+    }
+
+    public void setX(Double x) {
+        this.x = x;
+    }
+
+    public void setY(Double y) {
+        this.y = y;
+    }
+
+    public void setRadius(Double radius) {
+        this.radius = radius;
     }
 
     public MultiPolygon getPolygons() {
@@ -296,13 +309,15 @@ public class Region {
     }
 
     protected static void parseCircles(Region region, List<List<Double>> geo) {
-        for (List<Double> c : geo) {
-            Double radius = ObjectUtils.to(Double.class, c.get(2));
-            Double lat = ObjectUtils.to(Double.class, c.get(1));
-            Double lng = ObjectUtils.to(Double.class, c.get(0));
+        if (geo != null) {
+            for (List<Double> c : geo) {
+                Double radius = ObjectUtils.to(Double.class, c.get(2));
+                Double lat = ObjectUtils.to(Double.class, c.get(1));
+                Double lng = ObjectUtils.to(Double.class, c.get(0));
 
-            Circle circle = new Circle(lat, lng, radius);
-            region.addCircle(circle);
+                Circle circle = new Circle(lat, lng, radius);
+                region.addCircle(circle);
+            }
         }
     }
 

--- a/db/src/main/java/com/psddev/dari/db/StateValueUtils.java
+++ b/db/src/main/java/com/psddev/dari/db/StateValueUtils.java
@@ -372,7 +372,13 @@ abstract class StateValueUtils {
                     Map<String, Object> map = (Map<String, Object>) value;
 
                     Region region = Region.parseGeoJson(map);
-                    Region.parseCircles(region, (List<List<Double>>) map.get("circles"));
+                    if (map.get("circles") != null) {
+                        Region.parseCircles(region, (List<List<Double>>) map.get("circles"));
+                    }
+                    // yes this is deprecated but still pass it for now
+                    region.setX((Double) map.get("x"));
+                    region.setY((Double) map.get("y"));
+                    region.setRadius((Double) map.get("radius"));
 
                     return region;
                 }


### PR DESCRIPTION
When using Region.sphericalCircle it forgets to init circles. Also when writing the convertor to the DB this can cause null pointer exceptions. This fixes the nulls and adds some protection.