### PR TITLE
BSP-3290: Changes the save of DistributedLock key to skip validation and triggers.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/DistributedLock.java
+++ b/db/src/main/java/com/psddev/dari/db/DistributedLock.java
@@ -117,7 +117,15 @@ public class DistributedLock implements Lock {
             try {
                 key.replaceAtomically("lockId", lockId);
                 key.replaceAtomically("lastPing", database.now());
-                key.saveImmediately();
+
+                // saveImmediately (unsafely)
+                database.beginIsolatedWrites();
+                try {
+                    database.saveUnsafely(key);
+                    database.commitWrites();
+                } finally {
+                    database.endWrites();
+                }
 
             } catch (DatabaseException ex) {
                 Throwable cause = ex.getCause();


### PR DESCRIPTION
Since the key is an adhoc type-less object, this ensures that any global modification triggers aren't fired potentially causing unintended mutations to the key's state.