### PR TITLE
BSP-3578: Adds query phrase support.

### DIFF
--- a/db/src/main/java/com/psddev/dari/db/QueryPhrase.java
+++ b/db/src/main/java/com/psddev/dari/db/QueryPhrase.java
@@ -1,6 +1,6 @@
 package com.psddev.dari.db;
 
-public class QueryPhrase {
+public final class QueryPhrase {
 
     private String phrase;
     private int proximity;

--- a/db/src/main/java/com/psddev/dari/db/QueryPhrase.java
+++ b/db/src/main/java/com/psddev/dari/db/QueryPhrase.java
@@ -1,0 +1,30 @@
+package com.psddev.dari.db;
+
+public class QueryPhrase {
+
+    private String phrase;
+    private int proximity;
+    private double weight;
+
+    public static QueryPhraseBuilder builder() {
+        return new QueryPhraseBuilder();
+    }
+
+    QueryPhrase(String phrase, int proximity, double weight) {
+        this.phrase = phrase;
+        this.proximity = proximity;
+        this.weight = weight;
+    }
+
+    public String getPhrase() {
+        return phrase;
+    }
+
+    public int getProximity() {
+        return proximity;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+}

--- a/db/src/main/java/com/psddev/dari/db/QueryPhraseBuilder.java
+++ b/db/src/main/java/com/psddev/dari/db/QueryPhraseBuilder.java
@@ -1,0 +1,27 @@
+package com.psddev.dari.db;
+
+class QueryPhraseBuilder {
+
+    private String phrase;
+    private int proximity;
+    private double weight;
+
+    public QueryPhraseBuilder phrase(String phrase) {
+        this.phrase = phrase;
+        return this;
+    }
+
+    public QueryPhraseBuilder proximity(int proximity) {
+        this.proximity = proximity;
+        return this;
+    }
+
+    public QueryPhraseBuilder weight(double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    public QueryPhrase build() {
+        return new QueryPhrase(phrase, proximity, weight);
+    }
+}

--- a/db/src/main/java/com/psddev/dari/db/QueryPhraseBuilder.java
+++ b/db/src/main/java/com/psddev/dari/db/QueryPhraseBuilder.java
@@ -1,10 +1,13 @@
 package com.psddev.dari.db;
 
-class QueryPhraseBuilder {
+public final class QueryPhraseBuilder {
 
     private String phrase;
     private int proximity;
     private double weight;
+
+    QueryPhraseBuilder() {
+    }
 
     public QueryPhraseBuilder phrase(String phrase) {
         this.phrase = phrase;

--- a/db/src/main/java/com/psddev/dari/db/SolrDatabase.java
+++ b/db/src/main/java/com/psddev/dari/db/SolrDatabase.java
@@ -809,6 +809,28 @@ public class SolrDatabase extends AbstractDatabase<SolrServer> {
             for (Object value : values) {
                 if (ObjectUtils.isBlank(value)) {
                     comparisonBuilder.append("(*:* && -*:*)");
+
+                } else if (value instanceof QueryPhrase) {
+                    QueryPhrase phrase = (QueryPhrase) value;
+
+                    comparisonBuilder.append('"');
+                    comparisonBuilder.append(escapeValue(phrase.getPhrase()));
+                    comparisonBuilder.append('"');
+
+                    int proximity = phrase.getProximity();
+
+                    if (proximity > 0) {
+                        comparisonBuilder.append('~');
+                        comparisonBuilder.append(proximity);
+                    }
+
+                    double weight = phrase.getWeight();
+
+                    if (weight > 0.0) {
+                        comparisonBuilder.append('^');
+                        comparisonBuilder.append(weight);
+                    }
+
                 } else {
                     addValue(comparisonBuilder, solrField, value);
                 }

--- a/db/src/main/java/com/psddev/dari/db/SqlQuery.java
+++ b/db/src/main/java/com/psddev/dari/db/SqlQuery.java
@@ -701,6 +701,9 @@ class SqlQuery {
                             comparisonBuilder.append(" IS NULL");
                         }
 
+                    } else if (value instanceof QueryPhrase) {
+                        throw new UnsupportedOperationException();
+
                     } else if (value instanceof Region) {
                         if (!database.isIndexSpatial()) {
                             throw new UnsupportedOperationException();
@@ -826,6 +829,9 @@ class SqlQuery {
 
                         if (value == null) {
                             comparisonBuilder.append("0 = 1");
+
+                        } else if (value instanceof QueryPhrase) {
+                            throw new UnsupportedOperationException();
 
                         } else if (value instanceof Location) {
                             if (!database.isIndexSpatial()) {

--- a/sql/src/main/java/com/psddev/dari/sql/SqlQuery.java
+++ b/sql/src/main/java/com/psddev/dari/sql/SqlQuery.java
@@ -15,6 +15,7 @@ import com.psddev.dari.db.ObjectIndex;
 import com.psddev.dari.db.Predicate;
 import com.psddev.dari.db.PredicateParser;
 import com.psddev.dari.db.Query;
+import com.psddev.dari.db.QueryPhrase;
 import com.psddev.dari.db.Region;
 import com.psddev.dari.db.Sorter;
 import com.psddev.dari.db.SqlDatabase;
@@ -307,6 +308,9 @@ class SqlQuery {
                 for (Object value : comparisonPredicate.resolveValues(database)) {
                     if (value == null) {
                         comparisonConditions.add(DSL.falseCondition());
+
+                    } else if (value instanceof QueryPhrase) {
+                        throw new UnsupportedOperationException();
 
                     } else if (value == Query.MISSING_VALUE) {
                         hasMissing = true;


### PR DESCRIPTION
Usage:

```java
Query.from(Article.class)
    .where("_any matches ?", QueryPhrase.builder()
        .phrase("hello world")
        .proximity(2) // how far apart can the words in this phrase be?
        .weight(10.0) // how important is this phrase?
        .build()) // equivalent to (_any:"hello world"~2^10.0) in Solr
    .select(0, 10);
```